### PR TITLE
fix(ios): initialContext not always set before name

### DIFF
--- a/ios/ReactNativePortals.swift
+++ b/ios/ReactNativePortals.swift
@@ -74,6 +74,7 @@ class PortalViewManager: RCTViewManager {
 
 class PortalView: UIView {
     private var webView: PortalUIView?
+    private var _initialContext: [String: JSValue]?
     
     @objc var name: String? {
         get {
@@ -88,21 +89,18 @@ class PortalView: UIView {
     }
     
     @objc var initialContext: [String: Any]? {
-        get {
-            guard let portal = _portal else { return nil }
-            return portal.initialContext
-        }
-        
-        set {
-            guard let name = name else { return }
-            _portal = PortalManager.getPortal(named: name)
-            _portal?.initialContext = JSTypes.coerceDictionaryToJSObject(newValue) ?? [:]
-        }
+        get { _initialContext }
+        set { _initialContext = JSTypes.coerceDictionaryToJSObject(newValue) }
     }
     
     private var _portal: Portal? {
         didSet {
-            guard let portal = _portal else { return }
+            guard var portal = _portal else { return }
+            
+            if let initialContext = _initialContext {
+                portal.initialContext = initialContext
+            }
+            
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 self.webView?.removeFromSuperview()

--- a/ios/ReactNativePortals.swift
+++ b/ios/ReactNativePortals.swift
@@ -90,7 +90,11 @@ class PortalView: UIView {
     
     @objc var initialContext: [String: Any]? {
         get { _initialContext }
-        set { _initialContext = JSTypes.coerceDictionaryToJSObject(newValue) }
+        set {
+            _initialContext = JSTypes.coerceDictionaryToJSObject(newValue)
+            // If the Portal is already present then we need to set the initialContext so it's the `didSet` property observer is fired
+            _portal?.initialContext = _initialContext ?? [:]
+        }
     }
     
     private var _portal: Portal? {


### PR DESCRIPTION
fix(ios): Application of props is not guaranteed to be in any specific order. Setting initialContext may occur before the name prop is set and therefore will be unable to set any initialContext. To address this, we now store the initialContext on the view itself and then apply it to the portal just before rendering.