### PR TITLE
fix: update null-safety and array processing, bump version to 0.8.3

### DIFF
--- a/android/src/main/java/io/ionic/portals/reactnative/PortalView.kt
+++ b/android/src/main/java/io/ionic/portals/reactnative/PortalView.kt
@@ -19,7 +19,7 @@ import io.ionic.portals.WebVitals
 private data class PortalViewState(
     var fragment: PortalFragment?,
     var portal: RNPortal?,
-    var initialContext: HashMap<String, Any>?
+    var initialContext: HashMap<String, Any?>?
 )
 
 internal class PortalViewManager(private val context: ReactApplicationContext) :
@@ -30,11 +30,16 @@ internal class PortalViewManager(private val context: ReactApplicationContext) :
     @ReactProp(name = "portal")
     fun setPortal(viewGroup: ViewGroup, portal: ReadableMap) {
         val name = portal.getString("name") ?: return
+
+        // React Native 0.77 changed ReadableMap.toHashMap() from HashMap<String, Any> to HashMap<String, Any?>
+        // Casting is safe and keeps old versions compatible
+        val initialContext = portal.getMap("initialContext")?.toHashMap() as HashMap<String, Any?>?
+
         when (fragmentMap[viewGroup.id]) {
             null -> fragmentMap[viewGroup.id] = PortalViewState(
                 fragment = null,
                 portal = RNPortalManager.createPortal(portal),
-                initialContext = portal.getMap("initialContext")?.toHashMap()
+                initialContext
             )
         }
     }

--- a/android/src/main/java/io/ionic/portals/reactnative/ReactNativePortalManager.kt
+++ b/android/src/main/java/io/ionic/portals/reactnative/ReactNativePortalManager.kt
@@ -65,9 +65,11 @@ internal object RNPortalManager {
             ?.let { rnArray ->
                 val list = mutableListOf<PortalPlugin>()
                 for (idx in 0 until rnArray.size()) {
-                    rnArray.getMap(idx)
-                        .let(PortalPlugin.Companion::fromReadableMap)
-                        ?.let(list::add)
+                    rnArray.getMap(idx)?.let { map ->
+                        PortalPlugin.fromReadableMap(map)?.let { plugin ->
+                            list.add(plugin)
+                        }
+                    }
                 }
                 return@let list
             } ?: listOf()
@@ -83,16 +85,16 @@ internal object RNPortalManager {
                 val list = mutableListOf<AssetMap>()
 
                 for (idx in 0 until rnArray.size()) {
-                    rnArray.getMap(idx)
-                        .let assetMap@{ map ->
-                            val name = map.getString("name") ?: return@assetMap null
+                    rnArray.getMap(idx)?.let { map ->
+                        val assetMapName = map.getString("name") ?: return@let
+                        list.add(
                             AssetMap(
-                                name = name,
-                                virtualPath = map.getString("virtualPath") ?: "/$name",
+                                name = assetMapName,
+                                virtualPath = map.getString("virtualPath") ?: "/$assetMapName",
                                 path = map.getString("startDir") ?: ""
                             )
-                        }
-                        ?.let(list::add)
+                        )
+                    }
                 }
 
                 return@let list
@@ -115,16 +117,17 @@ internal object RNPortalManager {
                 )
             }
 
-         portalBuilder
+        portalBuilder
             .addPlugin(PortalsPlugin::class.java)
 
         val vitals = map.getArray("webVitals")
         val maybeList = if (vitals != null) {
             val size = vitals.size()
             (0 until size).fold(mutableListOf<String>()) { list, next ->
-                val vital = vitals.getString(next)
-                list.add(vital)
-                return@fold list
+                vitals.getString(next)?.let { vital ->
+                    list.add(vital)
+                }
+                list
             }
         } else {
             null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ionic/portals-react-native",
-  "version": "0.8.3-beta",
+  "version": "0.8.3",
   "description": "Portals for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ionic/portals-react-native",
-  "version": "0.8.2",
+  "version": "0.8.3-beta",
   "description": "Portals for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
- Updated PortalViewState.initialContext to HashMap<String, Any?>? to match RN 0.77 toHashMap() change.
- Normalized HashMaps to Any? internally for compatibility with older RN versions.
- Expanded nullable let chains (e.g., rnArray.getMap(idx)) to satisfy stricter Kotlin null-safety.